### PR TITLE
Prevent deadlock from other mods in item merge

### DIFF
--- a/src/main/java/net/himeki/mcmtfabric/mixin/ItemEntityMixin.java
+++ b/src/main/java/net/himeki/mcmtfabric/mixin/ItemEntityMixin.java
@@ -12,9 +12,11 @@ import java.util.concurrent.locks.ReentrantLock;
 public class ItemEntityMixin {
     private static final ReentrantLock lock = new ReentrantLock();
 
-    @Inject(method="tryMerge()V",at=@At(value="HEAD"))
+    @Inject(method="tryMerge()V",at=@At(value="HEAD"),cancellable=true)
     private void lock(CallbackInfo ci) {
-        lock.lock();
+        if (!lock.tryLock()) {
+            ci.cancel();
+        }
     }
 
     @Inject(method="tryMerge()V",at=@At(value="RETURN"))


### PR DESCRIPTION
Some mods change item behavior and may want to execute things when item are merged, the count is changed or when an entity is discarded, and may try to acquire another lock, but if a thread holding that lock causes an item merge (by moving items from world to world for example) the code will deadlock.

Simple solution to make this change safe for mods: if the lock is not free when attempting merging, just skip the merge. This barely ever happens in vanilla (and when it does, it doesn't matter because those rare cases will just be merged anyway the next tick), but at least the code can now never deadlock and give headaches in the future.